### PR TITLE
Perf/improve day1

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+rustflags = ["-C", "target-cpu=native"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,8 +86,10 @@ version = "0.1.0"
 dependencies = [
  "aoc-runner",
  "aoc-runner-derive",
+ "atoi",
  "codspeed-criterion-compat",
  "criterion",
+ "memchr",
  "pprof",
 ]
 
@@ -96,6 +98,15 @@ name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "atoi"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "autocfg"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,34 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+
+[[package]]
+name = "ahash"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+dependencies = [
+ "cfg-if",
+ "getrandom",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -59,7 +87,15 @@ dependencies = [
  "aoc-runner",
  "aoc-runner-derive",
  "codspeed-criterion-compat",
+ "criterion",
+ "pprof",
 ]
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "autocfg"
@@ -68,16 +104,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
+name = "backtrace"
+version = "0.3.74"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+
+[[package]]
 name = "bumpalo"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
+name = "bytemuck"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b37c88a63ffd85d15b406896cc343916d7cf57838a847b3a6f2ca5d39a5695a"
+
+[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
+name = "cc"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f34d93e62b03caf570cccc334cbc6c2fceca82f39211051345108adcba3eebdc"
+dependencies = [
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
@@ -237,10 +315,70 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
+name = "debugid"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
+dependencies = [
+ "uuid",
+]
+
+[[package]]
 name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+
+[[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
+name = "errno"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "486f806e73c5707928240ddc295403b1b93c96a02038563881c4a2fd84b81ac4"
+
+[[package]]
+name = "findshlibs"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40b9e59cd0f7e0806cca4be089683ecb6434e602038df21fe6bf6711b2f07f64"
+dependencies = [
+ "cc",
+ "lazy_static",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "gimli"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "half"
@@ -253,10 +391,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+
+[[package]]
 name = "hermit-abi"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
+
+[[package]]
+name = "indexmap"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
+
+[[package]]
+name = "inferno"
+version = "0.11.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "232929e1d75fe899576a3d5c7416ad0d88dbfbb3c3d6aa00873a7408a50ddb88"
+dependencies = [
+ "ahash",
+ "indexmap",
+ "is-terminal",
+ "itoa",
+ "log",
+ "num-format",
+ "once_cell",
+ "quick-xml",
+ "rgb",
+ "str_stack",
+]
 
 [[package]]
 name = "is-terminal"
@@ -307,6 +479,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09d6582e104315a817dff97f75133544b2e094ee22447d2acf4a74e189ba06fc"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+
+[[package]]
+name = "lock_api"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -319,12 +507,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
+name = "memmap2"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd3f7eed9d3848f8b98834af67102b720745c4ec028fcd0aa0239277e7de374f"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
+dependencies = [
+ "adler2",
+]
+
+[[package]]
+name = "nix"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
+name = "num-format"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a652d9771a63711fd3c3deb670acfbe5c30a4072e664d7a3bf5a9e1056ac72c3"
+dependencies = [
+ "arrayvec",
+ "itoa",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "object"
+version = "0.36.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aedf0a2d09c573ed1d8d85b30c119153926a2b36dce0ab28322c09a117a4683e"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -338,6 +574,29 @@ name = "oorandom"
 version = "11.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets 0.52.6",
+]
 
 [[package]]
 name = "plotters"
@@ -368,12 +627,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "pprof"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef5c97c51bd34c7e742402e216abdeb44d415fbe6ae41d56b114723e953711cb"
+dependencies = [
+ "backtrace",
+ "cfg-if",
+ "criterion",
+ "findshlibs",
+ "inferno",
+ "libc",
+ "log",
+ "nix",
+ "once_cell",
+ "parking_lot",
+ "smallvec",
+ "symbolic-demangle",
+ "tempfile",
+ "thiserror",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f50b1c63b38611e7d4d7f68b82d3ad0cc71a2ad2e7f61fc10f1328d917c93cd"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -406,6 +696,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
+dependencies = [
+ "bitflags 2.6.0",
+]
+
+[[package]]
 name = "regex"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -435,6 +734,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
+name = "rgb"
+version = "0.8.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57397d16646700483b67d2dd6511d79318f9d057fdbd21a4066aeac8b41d310a"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+
+[[package]]
+name = "rustix"
+version = "0.38.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7f649912bc1495e167a6edee79151c84b1bad49748cb4f1f1167f459f6224f6"
+dependencies = [
+ "bitflags 2.6.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -448,6 +775,12 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
@@ -482,6 +815,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "smallvec"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "str_stack"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9091b6114800a5f2141aee1d1b9d6ca3592ac062dc5decb3764ec5895a47b4eb"
+
+[[package]]
+name = "symbolic-common"
+version = "12.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5ba5365997a4e375660bed52f5b42766475d5bc8ceb1bb13fea09c469ea0f49"
+dependencies = [
+ "debugid",
+ "memmap2",
+ "stable_deref_trait",
+ "uuid",
+]
+
+[[package]]
+name = "symbolic-demangle"
+version = "12.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "beff338b2788519120f38c59ff4bb15174f52a183e547bac3d6072c2c0aa48aa"
+dependencies = [
+ "rustc-demangle",
+ "symbolic-common",
+]
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -504,6 +883,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28cce251fcbc87fac86a866eeb0d6c2d536fc16d06f184bb61aeae11aa4cee0c"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+]
+
+[[package]]
 name = "tinytemplate"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -520,6 +932,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
 
 [[package]]
+name = "uuid"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8c5f0a0af699448548ad1a2fbf920fb4bee257eae39953ba95cb84891a0446a"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
 name = "walkdir"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -528,6 +952,12 @@ dependencies = [
  "same-file",
  "winapi-util",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
@@ -595,6 +1025,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -602,6 +1048,12 @@ checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
@@ -750,3 +1202,23 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "zerocopy"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,6 +89,7 @@ dependencies = [
  "atoi",
  "codspeed-criterion-compat",
  "criterion",
+ "fxhash",
  "memchr",
  "pprof",
 ]
@@ -152,6 +153,12 @@ name = "bytemuck"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b37c88a63ffd85d15b406896cc343916d7cf57838a847b3a6f2ca5d39a5695a"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cast"
@@ -372,6 +379,15 @@ dependencies = [
  "lazy_static",
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,8 @@ edition = "2021"
 [dependencies]
 aoc-runner = "0.3.0"
 aoc-runner-derive = "0.3.0"
+atoi = "2.0.0"
+memchr = "2.7.4"
 
 [dev-dependencies]
 codspeed-criterion = { version = "2.7.2", package = "codspeed-criterion-compat" }
@@ -17,11 +19,21 @@ pprof = { version = "0.13.0", default-features = false, features = [
 ] }
 
 [profile.release]
+codegen-units = 1
+lto = "fat"
+panic = "abort"
+strip = true
+
+[profile.bench]
+inherits = "release"
 debug = true
+strip = false
 
 [profile.profiling]
 inherits = "release"
 debug = true
+strip = false
+
 
 [[bin]]
 name = "aoc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,24 @@ aoc-runner = "0.3.0"
 aoc-runner-derive = "0.3.0"
 
 [dev-dependencies]
-criterion = { version = "2.7.2", package = "codspeed-criterion-compat" }
+codspeed-criterion = { version = "2.7.2", package = "codspeed-criterion-compat" }
+criterion = "0.5.1"
+pprof = { version = "0.13.0", default-features = false, features = [
+    "criterion",
+    "flamegraph",
+    "frame-pointer",
+] }
+
+[profile.release]
+debug = true
+
+[profile.profiling]
+inherits = "release"
+debug = true
+
+[[bin]]
+name = "aoc"
+path = "src/main.rs"
 
 [[bench]]
 name = "day1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 aoc-runner = "0.3.0"
 aoc-runner-derive = "0.3.0"
 atoi = "2.0.0"
+fxhash = "0.2.1"
 memchr = "2.7.4"
 
 [dev-dependencies]

--- a/benches/day1.rs
+++ b/benches/day1.rs
@@ -1,5 +1,6 @@
 use aoc_2024::day1::{part1, part2};
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use codspeed_criterion::{black_box, criterion_group, criterion_main, Criterion};
+// use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use pprof::criterion::{Output, PProfProfiler};
 
 pub fn criterion_benchmark(c: &mut Criterion) {

--- a/benches/day1.rs
+++ b/benches/day1.rs
@@ -1,5 +1,6 @@
 use aoc_2024::day1::{part1, part2};
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use pprof::criterion::{Output, PProfProfiler};
 
 pub fn criterion_benchmark(c: &mut Criterion) {
     let input = match std::env::var("AOC_INPUT_DAY01") {
@@ -12,5 +13,10 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("part2", |b| b.iter(|| part2(black_box(input))));
 }
 
-criterion_group!(benches, criterion_benchmark);
+criterion_group!(
+    name = benches;
+    config = Criterion::default().with_profiler(
+        PProfProfiler::new(100, Output::Flamegraph(None)));
+    targets = criterion_benchmark
+);
 criterion_main!(benches);

--- a/src/day1.rs
+++ b/src/day1.rs
@@ -1,19 +1,9 @@
 use core::str;
-use std::collections::HashMap;
 
 use aoc_runner_derive::aoc;
 use atoi::FromRadix10;
 use fxhash::FxHashMap;
 use memchr::{memchr, memmem};
-
-// starting with flamegraph
-fn parse_input(input: &str) -> (Vec<u32>, Vec<u32>) {
-    input
-        .split('\n')
-        .filter_map(|s| s.split_once("   "))
-        .map(|(a, b)| (a.parse::<u32>().unwrap(), b.parse::<u32>().unwrap()))
-        .unzip()
-}
 
 fn parse_input_memchr(input: &str) -> (Vec<u32>, Vec<u32>) {
     let mut data = input[..].as_bytes();
@@ -47,13 +37,12 @@ fn compute_distance(a_vec: &[u32], b_vec: &[u32]) -> u32 {
 
 #[aoc(day1, part1, Chars)]
 pub fn part1(input: &str) -> u32 {
-    // let (a_vec, b_vec) = parse_input(input);
     let (a_vec, b_vec) = parse_input_memchr(input);
     compute_distance(&a_vec, &b_vec)
 }
 
 fn compute_similarity_score(a_vec: &[u32], b_vec: &[u32]) -> u32 {
-    let mut freq_map = FxHashMap::default();
+    let mut freq_map = FxHashMap::with_capacity_and_hasher(b_vec.len(), Default::default());
     for &num in b_vec {
         *freq_map.entry(num).or_insert(0) += 1;
     }
@@ -63,7 +52,6 @@ fn compute_similarity_score(a_vec: &[u32], b_vec: &[u32]) -> u32 {
 
 #[aoc(day1, part2)]
 pub fn part2(input: &str) -> u32 {
-    // let (a_vec, b_vec) = parse_input(input);
     let (a_vec, b_vec) = parse_input_memchr(input);
     compute_similarity_score(&a_vec, &b_vec)
 }

--- a/src/day1.rs
+++ b/src/day1.rs
@@ -1,9 +1,10 @@
+use core::str;
+use std::collections::HashMap;
+
 use aoc_runner_derive::aoc;
 use atoi::FromRadix10;
-use core::str;
-use memchr::memchr;
-use memchr::memmem;
-use std::collections::HashMap;
+use fxhash::FxHashMap;
+use memchr::{memchr, memmem};
 
 // starting with flamegraph
 fn parse_input(input: &str) -> (Vec<u32>, Vec<u32>) {
@@ -52,7 +53,7 @@ pub fn part1(input: &str) -> u32 {
 }
 
 fn compute_similarity_score(a_vec: &[u32], b_vec: &[u32]) -> u32 {
-    let mut freq_map = HashMap::new();
+    let mut freq_map = FxHashMap::default();
     for &num in b_vec {
         *freq_map.entry(num).or_insert(0) += 1;
     }

--- a/src/day1.rs
+++ b/src/day1.rs
@@ -56,6 +56,14 @@ pub fn part2(input: &str) -> u32 {
     compute_similarity_score(&a_vec, &b_vec)
 }
 
+fn _parse_input(input: &str) -> (Vec<u32>, Vec<u32>) {
+    input
+        .split('\n')
+        .filter_map(|s| s.split_once("   "))
+        .map(|(a, b)| (a.parse::<u32>().unwrap(), b.parse::<u32>().unwrap()))
+        .unzip()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -87,7 +95,15 @@ mod tests {
         let input = INPUT;
         let expected_a_vec: Vec<u32> = vec![3, 4, 2, 1, 3, 3];
         let expected_b_vec: Vec<u32> = vec![4, 3, 5, 3, 9, 3];
-        assert_eq!(parse_input(input), (expected_a_vec, expected_b_vec));
+        assert_eq!(_parse_input(input), (expected_a_vec, expected_b_vec));
+    }
+
+    #[test]
+    fn test_parse_input_memchr() {
+        let input = INPUT;
+        let expected_a_vec: Vec<u32> = vec![3, 4, 2, 1, 3, 3];
+        let expected_b_vec: Vec<u32> = vec![4, 3, 5, 3, 9, 3];
+        assert_eq!(parse_input_memchr(input), (expected_a_vec, expected_b_vec));
     }
 
     #[test]

--- a/src/day1.rs
+++ b/src/day1.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use aoc_runner_derive::aoc;
 
+// starting with flamegraph
 fn parse_input(input: &str) -> (Vec<u32>, Vec<u32>) {
     input
         .split('\n')

--- a/src/day1.rs
+++ b/src/day1.rs
@@ -1,6 +1,9 @@
-use std::collections::HashMap;
-
 use aoc_runner_derive::aoc;
+use atoi::FromRadix10;
+use core::str;
+use memchr::memchr;
+use memchr::memmem;
+use std::collections::HashMap;
 
 // starting with flamegraph
 fn parse_input(input: &str) -> (Vec<u32>, Vec<u32>) {
@@ -9,6 +12,27 @@ fn parse_input(input: &str) -> (Vec<u32>, Vec<u32>) {
         .filter_map(|s| s.split_once("   "))
         .map(|(a, b)| (a.parse::<u32>().unwrap(), b.parse::<u32>().unwrap()))
         .unzip()
+}
+
+fn parse_input_memchr(input: &str) -> (Vec<u32>, Vec<u32>) {
+    let mut data = input[..].as_bytes();
+    let mut a_vec = Vec::with_capacity(1000);
+    let mut b_vec = Vec::with_capacity(1000);
+    let finder = memmem::Finder::new("   ");
+    loop {
+        let Some(separator) = finder.find(data) else {
+            break;
+        };
+        let end = memchr(b'\n', &data[separator..]).unwrap();
+        let a = &data[..separator];
+        let b = &data[separator + 3..separator + end];
+        let a = u32::from_radix_10(a);
+        let b = u32::from_radix_10(b);
+        a_vec.push(a.0);
+        b_vec.push(b.0);
+        data = &data[separator + end + 1..];
+    }
+    (a_vec, b_vec)
 }
 
 fn compute_distance(a_vec: &[u32], b_vec: &[u32]) -> u32 {
@@ -22,7 +46,8 @@ fn compute_distance(a_vec: &[u32], b_vec: &[u32]) -> u32 {
 
 #[aoc(day1, part1, Chars)]
 pub fn part1(input: &str) -> u32 {
-    let (a_vec, b_vec) = parse_input(input);
+    // let (a_vec, b_vec) = parse_input(input);
+    let (a_vec, b_vec) = parse_input_memchr(input);
     compute_distance(&a_vec, &b_vec)
 }
 
@@ -37,7 +62,8 @@ fn compute_similarity_score(a_vec: &[u32], b_vec: &[u32]) -> u32 {
 
 #[aoc(day1, part2)]
 pub fn part2(input: &str) -> u32 {
-    let (a_vec, b_vec) = parse_input(input);
+    // let (a_vec, b_vec) = parse_input(input);
+    let (a_vec, b_vec) = parse_input_memchr(input);
     compute_similarity_score(&a_vec, &b_vec)
 }
 
@@ -50,7 +76,8 @@ mod tests {
 2   5
 1   3
 3   9
-3   3";
+3   3
+";
 
     #[test]
     fn sample1() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,15 @@
 // use aoc_runner_derive::aoc_main;
-
 // aoc_main! { lib = aoc_2024 }
 
-fn main() {
-    println!("Hello AoC");
+use aoc_2024::day1;
+
+fn main() -> () {
+    let input = include_str!("../input/2024/full/day1.txt");
+    let mut out1 = 0;
+    let mut out2 = 0;
+    for _i in 0..10_000 {
+        out1 = day1::part1(input);
+        out2 = day1::part2(input);
+    }
+    println!("{} {}", out1, out2);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@
 
 use aoc_2024::day1;
 
-fn main() -> () {
+fn main() {
     let input = include_str!("../input/2024/sample/day1.txt");
     let mut out1 = 0;
     let mut out2 = 0;

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@
 use aoc_2024::day1;
 
 fn main() -> () {
-    let input = include_str!("../input/2024/full/day1.txt");
+    let input = include_str!("../input/2024/sample/day1.txt");
     let mut out1 = 0;
     let mut out2 = 0;
     for _i in 0..10_000 {


### PR DESCRIPTION
perf: setup profiler to improve perf commit af2e0b8ee1bf489ad0b59ac1d217fca32158dad3 

```
    part1                   time:   [43.465 µs 43.505 µs 43.547 µs]
                            change: [-0.4149% -0.0859% +0.2330%] (p = 0.62 > 0.05)
                            No change in performance detected.
    Found 3 outliers among 100 measurements (3.00%)
      1 (1.00%) high mild
      2 (2.00%) high severe

    part2                   time:   [61.165 µs 61.226 µs 61.290 µs]
                            change: [-0.2693% +0.0569% +0.3443%] (p = 0.73 > 0.05)
                            No change in performance detected.
    Found 5 outliers among 100 measurements (5.00%)
      2 (2.00%) high mild
      3 (3.00%) high severe
```

perf: add memchr and atoi for parsing commit c7852699d6c75fd62ada0a9bfc5c1854479ad318

```
    part1                   time:   [17.639 µs 17.663 µs 17.692 µs]
                            change: [-56.508% -56.300% -56.038%] (p = 0.00 < 0.05)
                            Performance has improved.
    Found 10 outliers among 100 measurements (10.00%)
      4 (4.00%) high mild
      6 (6.00%) high severe

    part2                   time:   [34.221 µs 34.406 µs 34.587 µs]
                            change: [-40.109% -39.854% -39.613%] (p = 0.00 < 0.05)
                            Performance has improved.
    Found 7 outliers among 100 measurements (7.00%)
      7 (7.00%) high mild
```

perf: add fxhash for part 2 commit e2cd1a0dc083c6e67d62d961dadf94fbc03b9a5e
    
```
    part1                   time:   [17.821 µs 17.841 µs 17.861 µs]
                            change: [+0.1907% +0.8146% +1.2743%] (p = 0.00 < 0.05)
                            Change within noise threshold.
    Found 5 outliers among 100 measurements (5.00%)
      2 (2.00%) high mild
      3 (3.00%) high severe

    part2                   time:   [17.138 µs 17.191 µs 17.248 µs]
                            change: [-50.129% -49.925% -49.716%] (p = 0.00 < 0.05)
                            Performance has improved.
    Found 7 outliers among 100 measurements (7.00%)
      2 (2.00%) high mild
      5 (5.00%) high severe
```

perf: FxHashMap::with_capacity_and_hasher commit 271e7cbc8e8063259e65b09afc7a8dd594653147

```
part1                   time:   [17.552 µs 17.569 µs 17.587 µs]
                        change: [-1.5771% -1.1694% -0.7460%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) high mild
  2 (2.00%) high severe

part2                   time:   [11.568 µs 11.580 µs 11.593 µs]
                        change: [-31.551% -31.312% -31.099%] (p = 0.00 < 0.05)
                        Performance has improved.
```