### PR TITLE
perf: remove to vec to sort the slice

### DIFF
--- a/src/day1.rs
+++ b/src/day1.rs
@@ -26,19 +26,17 @@ fn parse_input_memchr(input: &str) -> (Vec<u32>, Vec<u32>) {
     (a_vec, b_vec)
 }
 
-fn compute_distance(a_vec: &[u32], b_vec: &[u32]) -> u32 {
-    let mut a_sorted = a_vec.to_vec();
-    let mut b_sorted = b_vec.to_vec();
-    a_sorted.sort_unstable();
-    b_sorted.sort_unstable();
+fn compute_distance(a_vec: &mut [u32], b_vec: &mut [u32]) -> u32 {
+    a_vec.sort_unstable();
+    b_vec.sort_unstable();
 
-    a_sorted.iter().zip(b_sorted.iter()).map(|(a, b)| b.abs_diff(*a)).sum()
+    a_vec.iter().zip(b_vec.iter()).map(|(a, b)| b.abs_diff(*a)).sum()
 }
 
 #[aoc(day1, part1, Chars)]
 pub fn part1(input: &str) -> u32 {
-    let (a_vec, b_vec) = parse_input_memchr(input);
-    compute_distance(&a_vec, &b_vec)
+    let (mut a_vec, mut b_vec) = parse_input_memchr(input);
+    compute_distance(&mut a_vec, &mut b_vec)
 }
 
 fn compute_similarity_score(a_vec: &[u32], b_vec: &[u32]) -> u32 {
@@ -108,9 +106,9 @@ mod tests {
 
     #[test]
     fn test_compute_distance() {
-        let a_vec: Vec<u32> = vec![3, 4, 2, 1, 3, 3];
-        let b_vec: Vec<u32> = vec![4, 3, 5, 3, 9, 3];
-        assert_eq!(compute_distance(&a_vec, &b_vec), 11);
+        let mut a_vec: Vec<u32> = vec![3, 4, 2, 1, 3, 3];
+        let mut b_vec: Vec<u32> = vec![4, 3, 5, 3, 9, 3];
+        assert_eq!(compute_distance(&mut a_vec, &mut b_vec), 11);
     }
 
     #[test]


### PR DESCRIPTION
perf: remove to vec to sort the slice commit a8157e501ae2fa82bafba76ecc44bad4a62f422d
```
part1                   time:   [123.79 ns 124.55 ns 125.43 ns]
                        change: [-20.742% -20.374% -19.969%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 14 outliers among 100 measurements (14.00%)
  1 (1.00%) low severe
  3 (3.00%) low mild
  2 (2.00%) high mild
  8 (8.00%) high severe

part2                   time:   [174.64 ns 175.45 ns 176.57 ns]
                        change: [+2.2454% +3.3422% +4.7322%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe
```